### PR TITLE
Remove redundant job from Check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,11 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Extract branch name
-        run: |
-          $SOURCE_BRANCH = ${env:GITHUB_REF} -replace 'refs/heads/', ''
-          echo "::set-env name=SOURCE_BRANCH::$SOURCE_BRANCH"
-
       - name: Check the commit message(s)
         uses: mristin/opinionated-commit-message@v1.0.4
 


### PR DESCRIPTION
This removes the redundant job `Extract branch name` from Check workflow
since it was merged in `Send to coveralls`.