### PR TITLE
Remove redundant job from Check (#5)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,11 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Extract branch name
-        run: |
-          $SOURCE_BRANCH = ${env:GITHUB_REF} -replace 'refs/heads/', ''
-          echo "::set-env name=SOURCE_BRANCH::$SOURCE_BRANCH"
-
       - name: Check the commit message(s)
         uses: mristin/opinionated-commit-message@v1.0.4
 

--- a/.github/workflows/generate-nuget.yml
+++ b/.github/workflows/generate-nuget.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.100'
+          source-url: https://nuget.pkg.github.com/mristin/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_KEY}}
 
@@ -26,4 +27,4 @@ jobs:
 
       - name: Push generated package
         working-directory: src
-        run: dotnet nuget push out/*.nupkg --skip-duplicate --no-symbols true
+        run: dotnet nuget push out/*.nupkg --skip-duplicate --no-symbols true --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This removes the redundant job `Extract branch name` from Check workflow
since it was merged in `Send to coveralls`.