### PR TITLE
Change actions to ignore doc and workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,10 @@
 name: Check
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - '*/doc/*'
+      - '*/workflow/*'
 
 jobs:
   Execute:

--- a/.github/workflows/reduced-check.yml
+++ b/.github/workflows/reduced-check.yml
@@ -1,0 +1,16 @@
+name: Reduced-Check
+
+on:
+  push:
+    branches:
+      - '*/doc/*'
+      - '*/workflow/*'
+
+jobs:
+  Execute:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Check the commit message(s)
+        uses: mristin/opinionated-commit-message@v1.0.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,10 @@
 We develop using the feature branches, see this section of the Git book:
 https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows.
 
-Please prefix the branch with your user name
-(*e.g.,* `mristin/Add-some-feature`).
+Please prefix the branch with your user name (*e.g.,* `mristin/Add-some-feature`). 
+If you want to skip the full battery of CI tests, you can add `doc` or `workflow` 
+qualifier in your branch name (*e.g.*, `mristin/doc/Add-references-to-Readme` or
+`mristin/workflow/Fix-nuget-publishing`).
 
 If you have write permissions to the repository,
 create a feature branch directly within the repository.


### PR DESCRIPTION
This introduces selectors for branches to distinguish between pull
requests related to documentation and workflows, and code. The former
need not to run a full battery of CI tests while the latter have to
pass all the checks.