### PR TITLE
Hide implementation details

### DIFF
--- a/src/DeadCsharp/AssemblyInfo.cs
+++ b/src/DeadCsharp/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DeadCsharp.Test")]

--- a/src/DeadCsharp/Input.cs
+++ b/src/DeadCsharp/Input.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace DeadCsharp
 {
-    public static class Input
+    internal static class Input
     {
         /// <summary>
         /// Matches all the files defined by the patterns, includes and excludes.


### PR DESCRIPTION
Some of the methods had to be made public in order to test them.
This changes these methods to internal and makes the internal
visible to the test assembly.