### PR TITLE
Detect dead attributes

### DIFF
--- a/src/DeadCsharp.Test/TestInspection.cs
+++ b/src/DeadCsharp.Test/TestInspection.cs
@@ -20,6 +20,7 @@ namespace DeadCsharp.Test
         [TestCase("// if(something) {", new[] { "a line ends with `{`" })]
         [TestCase("// }  ", new[] { "a line ends with `}`" })]
         [TestCase("// doSomething(  ", new[] { "a line ends with `(`" })]
+        [TestCase("// [SomeAttribute()] ", new[] { @"a line matches `^\s*\[`" })]
         public void TestTrivialCases(string triviaAsString, string[]? expected)
         {
             List<string>? actual = Inspection.InspectComment(triviaAsString);

--- a/src/DeadCsharp/Inspection.cs
+++ b/src/DeadCsharp/Inspection.cs
@@ -104,7 +104,10 @@ namespace DeadCsharp
                       @"new\s*.*\(.*\)$"),
 
             // Wagon function call
-            new Regex(@"^\s*\.([a-zA-Z_0-9]+(\.[a-zA-Z_0-9]+)*)\(.*\)\s*$")
+            new Regex(@"^\s*\.([a-zA-Z_0-9]+(\.[a-zA-Z_0-9]+)*)\(.*\)\s*$"),
+            
+            // Attribute suffix and prefix
+            new Regex( @"^\s*\[")
         };
 
         /// <summary>


### PR DESCRIPTION
The dead attributes are particularly confusing part of the dead code.
This adds a simple heuristic to detect them by looking at the prefix
(such as `// [...`).