### PR TITLE
Make internal methods public again

### DIFF
--- a/src/DeadCsharp/AssemblyInfo.cs
+++ b/src/DeadCsharp/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("DeadCsharp.Test")]

--- a/src/DeadCsharp/Input.cs
+++ b/src/DeadCsharp/Input.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace DeadCsharp
 {
-    internal static class Input
+    public static class Input
     {
         /// <summary>
         /// Matches all the files defined by the patterns, includes and excludes.

--- a/src/DeadCsharp/Inspection.cs
+++ b/src/DeadCsharp/Inspection.cs
@@ -47,7 +47,7 @@ namespace DeadCsharp
             }
         }
 
-        internal static bool ShouldSkipTrivia(string triviaAsString)
+        public static bool ShouldSkipTrivia(string triviaAsString)
         {
             return triviaAsString.StartsWith("///") ||
                    (!triviaAsString.StartsWith("//") && !triviaAsString.StartsWith("/*"));
@@ -115,7 +115,7 @@ namespace DeadCsharp
         /// </summary>
         /// <param name="triviaAsText">Comment's content from the trivia node of the syntax tree</param>
         /// <returns>null if no cues or a list with one or more cues</returns>
-        internal static List<string>? InspectComment(string triviaAsText)
+        public static List<string>? InspectComment(string triviaAsText)
         {
             string content = ExtractContent(triviaAsText);
 
@@ -210,7 +210,7 @@ namespace DeadCsharp
             }
         }
 
-        internal static bool TriviaIsComment(string triviaAsString)
+        private static bool TriviaIsComment(string triviaAsString)
         {
             return triviaAsString.StartsWith("//") || triviaAsString.StartsWith("/*");
         }


### PR DESCRIPTION
Internal methods and internal-visibles in `AssemblyInfo.cs` do not
play well with coveralls and test coverage. All the methods which
are tested are again made public.