### PR TITLE
Report cues more precisely line-wise

### DIFF
--- a/src/DeadCsharp.Test/TestInput.cs
+++ b/src/DeadCsharp.Test/TestInput.cs
@@ -7,14 +7,13 @@ namespace DeadCsharp.Test
 {
     public class InputTests
     {
-        private static string WriteDummyFile(string prefix, string dirName, string subdirName, string name)
+        private static void WriteDummyFile(string prefix, string dirName, string subdirName, string name)
         {
             var parent = Path.Join(prefix, dirName, subdirName);
             System.IO.Directory.CreateDirectory(parent);
 
             var path = Path.Join(parent, name);
             System.IO.File.WriteAllText(path, "some content");
-            return path;
         }
 
         [Test]
@@ -26,8 +25,8 @@ namespace DeadCsharp.Test
 
             List<string> matchedFiles = Input.MatchFiles(
                     tmpdir.Path,
-                    new List<string>() { Path.Join("**", "*.cs") },
-                    new List<string>() { })
+                    new List<string> { Path.Join("**", "*.cs") },
+                    new List<string>())
                 .ToList();
 
             var expectedFiles = new List<string>() { Path.Join("a", "b", "Program.cs") };
@@ -44,8 +43,8 @@ namespace DeadCsharp.Test
 
             List<string> matchedFiles = Input.MatchFiles(
                     tmpdir.Path,
-                    new List<string>() { Path.Join(tmpdir.Path, "**", "*.cs") },
-                    new List<string>() { })
+                    new List<string> { Path.Join(tmpdir.Path, "**", "*.cs") },
+                    new List<string>())
                 .ToList();
 
             var expectedFiles = new List<string>() { Path.Join(tmpdir.Path, "a", "b", "Program.cs") };

--- a/src/DeadCsharp.Test/TestProgram.cs
+++ b/src/DeadCsharp.Test/TestProgram.cs
@@ -81,7 +81,46 @@ namespace HelloWorld
 
             Assert.AreEqual(1, exitCode);
             Assert.AreEqual(
-                $"FAIL {path}:{nl}  * 8:13: a line ends with `;`{nl}",
+                $"FAIL {path}:{nl}" +
+                $"  * Comment starting at 8:13:{nl}" +
+                $"    * Cue at 8:24: a line ends with `;`{nl}",
+                consoleCapture.Output());
+        }
+
+        [Test]
+        public void TestMatchedPatternsReported()
+        {
+            using var tmpdir = new TemporaryDirectory();
+
+            string path = System.IO.Path.Join(tmpdir.Path, "SomeProgram.cs");
+            const string programText =
+                @"
+namespace HelloWorld
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // if(isDead)
+            System.Console.WriteLine(""Hello, World!"");
+        }
+    }
+}";
+            using var consoleCapture = new ConsoleCapture();
+
+            System.IO.File.WriteAllText(path, programText);
+
+            int exitCode = Program.MainWithCode(new[] { "--inputs", path });
+
+            string nl = Environment.NewLine;
+
+            Assert.AreEqual(1, exitCode);
+            Assert.AreEqual(
+                $"FAIL {path}:{nl}" +
+                $"  * Comment starting at 8:13:{nl}" +
+                $"    * Cue at 8:16: a line matches the pattern \"control statement\"{nl}" +
+                $"The matched patterns were:{nl}" +
+                $@"  * ""control statement"": ^\s*(if|else\s+if|for|foreach|switch|while)\s*\(.*\)\s*${nl}",
                 consoleCapture.Output());
         }
 
@@ -117,8 +156,12 @@ namespace HelloWorld
 
             Assert.AreEqual(1, exitCode);
             Assert.AreEqual(
-                $"FAIL {path2}:{nl}  * 8:13: a line ends with `;`{nl}" +
-                $"FAIL {path1}:{nl}  * 8:13: a line ends with `;`{nl}",
+                $"FAIL {path2}:{nl}" +
+                $"  * Comment starting at 8:13:{nl}" +
+                $"    * Cue at 8:24: a line ends with `;`{nl}" +
+                $"FAIL {path1}:{nl}" +
+                $"  * Comment starting at 8:13:{nl}" +
+                $"    * Cue at 8:24: a line ends with `;`{nl}",
                 consoleCapture.Output());
         }
 
@@ -159,7 +202,9 @@ namespace HelloWorld
 
             Assert.AreEqual(1, exitCode);
             Assert.AreEqual(
-                $"FAIL {includedPath}:{nl}  * 8:13: a line ends with `;`{nl}",
+                $"FAIL {includedPath}:{nl}" +
+                $"  * Comment starting at 8:13:{nl}" +
+                $"    * Cue at 8:24: a line ends with `;`{nl}",
                 consoleCapture.Output());
         }
 

--- a/src/DeadCsharp.sln.DotSettings
+++ b/src/DeadCsharp.sln.DotSettings
@@ -1,0 +1,5 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Regexes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rewriter/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subdir/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Trivias/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/DeadCsharp/Program.cs
+++ b/src/DeadCsharp/Program.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 
 namespace DeadCsharp
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
     public class Program
     {
         private static int Handle(string[] inputs, string[]? excludes, bool remove)
@@ -42,15 +43,9 @@ namespace DeadCsharp
                 {
                     IEnumerable<Inspection.Suspect> suspects = Inspection.Inspect(tree);
 
-                    var hasSuspect = new Output.HasSuspect();
-                    IEnumerable<string> lines = Output.Report(path, suspects, hasSuspect);
+                    bool hasSuspect = Output.Report(path, suspects, Console.Out);
 
-                    foreach (string line in lines)
-                    {
-                        Console.WriteLine(line);
-                    }
-
-                    if (hasSuspect.Value)
+                    if (hasSuspect)
                     {
                         exitCode = 1;
                     }


### PR DESCRIPTION
Previously, dead-csharp only reported the start of the offending
comment. This is not very useful in case of very long comments.

This change pins the cues at the first relevant line in file, not the
comment start.