### PR TITLE
Fix firing false positives on URLs

### DIFF
--- a/src/DeadCsharp.Test/TestInspection.cs
+++ b/src/DeadCsharp.Test/TestInspection.cs
@@ -18,8 +18,10 @@ namespace DeadCsharp.Test
                 ("// Precondition(s)", null, "single-line valid comment with parentheses"),
                 ("/* A completely valid comment */", null, "single-line valid block comment"),
                 ("/* A completely \n\n valid comment */", null, "multi-line valid comment"),
+                ("// http://some-domain.com", null, "a valid single-line comment with URL"),
+                ("/* http://some-domain.com */", null, "a valid block comment with URL"),
                 ("// var x; // do something",
-                    new List<(string, int, int)>{("a line contains `//`", 100, 210)},
+                    new List<(string, int, int)>{("a line contains ` //`", 100, 209)},
                     "dead code with trailing single-line comment"),
                 ("// var x; /* do something",
                     new List<(string, int, int)>
@@ -33,7 +35,7 @@ namespace DeadCsharp.Test
                 ("/*\n" +
                  "// do something\n" +
                  "*/",
-                    new List<(string, int, int)> { ("a line contains `//`", 101, 0) },
+                    new List<(string, int, int)> { ("a line starts with `//`", 101, 0) },
                     "Single-line comment in a block comment"),
                 ("// b &&",
                     new List<(string, int, int)> { ("a line contains `&&`", 100, 205) },

--- a/src/DeadCsharp/Inspection.cs
+++ b/src/DeadCsharp/Inspection.cs
@@ -166,7 +166,7 @@ namespace DeadCsharp
 
         private static readonly List<string> FeatureSubstrings = new List<string>
         {
-            "//", "/*", "*/", "||", "&&"
+            " //", "\t//", "/*", "*/", "||", "&&"
         };
 
         private static readonly Regex AllWhitespaceRegex = new Regex(@"^[ \t]*$");
@@ -277,6 +277,15 @@ namespace DeadCsharp
                             lineIndex + lineOffset,
                             first + columnOffset));
                 }
+                else if (line.Length - first >= 2 && line.Substring(first, 2) == "//")
+                {
+                    (cues ??= new List<Cue>()).Add(
+                        new Cue(
+                            new Prefixed("//"),
+                            lineIndex + lineOffset,
+                            first + columnOffset));
+                }
+
 
                 char lastChar = line[last];
                 if (lastChar == ';' || lastChar == '(' || lastChar == '{' || lastChar == '}' || lastChar == '=')


### PR DESCRIPTION
This patch fixes the algorithm so that it does not fire on URLs (which
indeed always contain `//` and hence confused the previous version of
the algorithm).