### PR TITLE
Fix firing on separator lines

### DIFF
--- a/src/DeadCsharp.Test/TestInspection.cs
+++ b/src/DeadCsharp.Test/TestInspection.cs
@@ -20,6 +20,12 @@ namespace DeadCsharp.Test
                 ("/* A completely \n\n valid comment */", null, "multi-line valid comment"),
                 ("// http://some-domain.com", null, "a valid single-line comment with URL"),
                 ("/* http://some-domain.com */", null, "a valid block comment with URL"),
+                ("/* ==========\n" +
+                 "A completely \n" +
+                 "valid comment\n" +
+                 "============= */",
+                    null,
+                    "multi-line valid comment with lines consisting of '='"),
                 ("// var x; // do something",
                     new List<(string, int, int)>{("a line contains ` //`", 100, 209)},
                     "dead code with trailing single-line comment"),
@@ -59,7 +65,7 @@ namespace DeadCsharp.Test
                     new List<(string, int, int)> { ("a line ends with `}`", 100, 203) },
                     "Single-line comment with trailing closing curly brace"),
                 ("// var x =",
-                    new List<(string, int, int)> { ("a line ends with `=`", 100, 209) },
+                    new List<(string, int, int)> { ("a line ends with `[^=]=`", 100, 209) },
                     "Single-line comment with trailing equal sign"),
                 ("// if (smc != null)",
                     new List<(string, int, int)>

--- a/src/DeadCsharp/Inspection.cs
+++ b/src/DeadCsharp/Inspection.cs
@@ -288,13 +288,26 @@ namespace DeadCsharp
 
 
                 char lastChar = line[last];
-                if (lastChar == ';' || lastChar == '(' || lastChar == '{' || lastChar == '}' || lastChar == '=')
+                if (lastChar == ';' || lastChar == '(' || lastChar == '{' || lastChar == '}')
                 {
                     (cues ??= new List<Cue>()).Add(
                         new Cue(
                             new Trailing(lastChar.ToString()),
                             lineIndex + lineOffset,
                             last + columnOffset));
+                }
+
+                if (last >= 1)
+                {
+                    string lastTwoChars = line.Substring(last - 1, 2);
+                    if (lastTwoChars[0] != '=' && lastTwoChars[1] == '=')
+                    {
+                        (cues ??= new List<Cue>()).Add(
+                            new Cue(
+                                new Trailing("[^=]="),
+                                lineIndex + lineOffset,
+                                last + columnOffset));
+                    }
                 }
 
                 foreach (var (identifier, regex) in CodeRegexes)


### PR DESCRIPTION
Previously, the algorithm considered horizontal lines expressed as
`==========` to be assignments. This patch fixes these false positives
by enforcing that any assignment operator must be preceded by a
non-assignment (`=`) character.