### PR TITLE
Release v1.0.0-beta5

### DIFF
--- a/src/DeadCsharp/DeadCsharp.csproj
+++ b/src/DeadCsharp/DeadCsharp.csproj
@@ -3,7 +3,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Nullable>enable</Nullable>
-        <Version>1.0.0-beta4</Version>
+        <Version>1.0.0-beta5</Version>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>dead-csharp</ToolCommandName>
     </PropertyGroup>


### PR DESCRIPTION
This marks the release of 1.0.0-beta5 which reports more precise cues
and allows skipping individual comments.