### PR TITLE
Upgrade tools to latest versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v2.1.0
+        uses: mristin/opinionated-commit-message@v2.1.2
 
       - name: Install .NET core
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/reduced-check.yml
+++ b/.github/workflows/reduced-check.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.4
+        uses: mristin/opinionated-commit-message@v2.1.2

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "coveralls.net": {
-      "version": "1.0.0",
+      "version": "2.0.0-beta0002",
       "commands": [
         "csmacnz.Coveralls"
       ]


### PR DESCRIPTION
This patch upgrades all the tools to the latest version. Coveralls.net
had to be upgraded and I used the opportunity to upgrade the rest as
well.