### PR TITLE
Update to net6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install .NET core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.100'
+          dotnet-version: '6.x'
 
       - name: Restore dotnet tools
         working-directory: src
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check format
         working-directory: src
-        run: dotnet format --check
+        run: dotnet format --verify-no-changes
 
       - name: dotnet publish
         working-directory: src

--- a/src/DeadCsharp.Test/DeadCsharp.Test.csproj
+++ b/src/DeadCsharp.Test/DeadCsharp.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/DeadCsharp/DeadCsharp.csproj
+++ b/src/DeadCsharp/DeadCsharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Version>1.0.0</Version>
         <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
.net6 is the current LTS version, supported until November 2024.
https://dotnet.microsoft.com/en-us/download/dotnet

My goal is to get `doctest-csharp` updated to net6 (so I can use it 
without installing .net3.1 runtime). To do that and keep the CI 
builds running successfully, this project (`dead-csharp`) and 
`bite-sized-csharp` (which uses `dead-csharp`) need to be updated.