### PR TITLE
Upgrade coveralls tool to latest

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,10 +15,15 @@ jobs:
       - name: Check the commit message(s)
         uses: mristin/opinionated-commit-message@v2.1.2
 
-      - name: Install .NET core
+      - name: Install .NET
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.x'
+
+      - name: Setup .NET 5.0 (needed for coveralls.net)
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
 
       - name: Restore dotnet tools
         working-directory: src

--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "coveralls.net": {
-      "version": "2.0.0-beta0002",
+      "version": "3.0.0",
       "commands": [
         "csmacnz.Coveralls"
       ]


### PR DESCRIPTION
We need the latest version since we migrated to net6.