### PR TITLE
Add count by file output option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 out/
+.suo
+.vs

--- a/src/DeadCsharp.Test/TestOutput.cs
+++ b/src/DeadCsharp.Test/TestOutput.cs
@@ -23,6 +23,20 @@ namespace DeadCsharp.Test
         }
 
         [Test]
+        public void TestNoSuspectsCountByFile()
+        {
+            string path = "/some/Program.cs";
+
+            using var writer = new StringWriter();
+            bool hasSuspect = Output.ReportCountByFile(path, new List<Inspection.Suspect>(), writer);
+
+            string nl = System.Environment.NewLine;
+
+            Assert.IsFalse(hasSuspect);
+            Assert.AreEqual($"OK   /some/Program.cs{nl}", writer.ToString());
+        }
+
+        [Test]
         public void TestOneSuspectOneCue()
         {
             string path = "/some/Program.cs";
@@ -45,6 +59,30 @@ namespace DeadCsharp.Test
                 $"FAIL /some/Program.cs:{nl}" +
                 $"  * Comment starting at 3:2:{nl}" +
                 $"    * Cue at 4:5: a line contains `something`{nl}",
+                writer.ToString());
+        }
+
+        [Test]
+        public void TestOneSuspectOneCueCountByFile()
+        {
+            string path = "/some/Program.cs";
+            var suspects = new List<Inspection.Suspect>
+            {
+                new Inspection.Suspect(
+                    2, 1,
+                    new List<Inspection.Cue>
+                    {
+                        new Inspection.Cue(new Inspection.Contains( "something"), 3, 4)
+                    })
+            };
+
+            string nl = System.Environment.NewLine;
+            using var writer = new StringWriter();
+            bool hasSuspect = Output.ReportCountByFile(path, suspects, writer);
+
+            Assert.IsTrue(hasSuspect);
+            Assert.AreEqual(
+                $"FAIL /some/Program.cs: 1{nl}",
                 writer.ToString());
         }
 
@@ -76,6 +114,34 @@ namespace DeadCsharp.Test
                 $"  * Comment starting at 3:2:{nl}" +
                 $"    * Cue at 4:5: a line contains `some feature`{nl}" +
                 $"    * Cue at 6:7: a line contains `another feature`{nl}",
+                writer.ToString());
+        }
+
+        [Test]
+        public void TestOneSuspectMultipleCuesCountByFile()
+        {
+            string path = "/some/Program.cs";
+            var suspects = new List<Inspection.Suspect>
+            {
+                new Inspection.Suspect(
+                    2, 1,
+                    new List<Inspection.Cue>
+                    {
+                        new Inspection.Cue(
+                            new Inspection.Contains("some feature"), 3, 4),
+                        new Inspection.Cue(
+                            new Inspection.Contains("another feature"), 5, 6)
+                    })
+            };
+
+            string nl = System.Environment.NewLine;
+
+            using var writer = new StringWriter();
+            bool hasSuspect = Output.ReportCountByFile(path, suspects, writer);
+
+            Assert.IsTrue(hasSuspect);
+            Assert.AreEqual(
+                $"FAIL /some/Program.cs: 2{nl}",
                 writer.ToString());
         }
 
@@ -113,6 +179,39 @@ namespace DeadCsharp.Test
                 $"    * Cue at 4:5: a line contains `some feature`{nl}" +
                 $"  * Comment starting at 13:2:{nl}" +
                 $"    * Cue at 14:15: a line contains `another feature`{nl}",
+                writer.ToString());
+        }
+
+        [Test]
+        public void TestMultipleSuspectsCountByFile()
+        {
+            string path = "/some/Program.cs";
+            var suspects = new List<Inspection.Suspect>()
+            {
+                new Inspection.Suspect(
+                    2, 1,
+                    new List<Inspection.Cue>
+                    {
+                        new Inspection.Cue(
+                            new Inspection.Contains("some feature"), 3, 4)
+                    }),
+                new Inspection.Suspect(
+                    12, 1,
+                    new List<Inspection.Cue>
+                    {
+                        new Inspection.Cue(
+                            new Inspection.Contains("another feature"), 13, 14)
+                    })
+            };
+
+            string nl = System.Environment.NewLine;
+
+            using var writer = new StringWriter();
+            bool hasSuspect = Output.ReportCountByFile(path, suspects, writer);
+
+            Assert.IsTrue(hasSuspect);
+            Assert.AreEqual(
+                $"FAIL /some/Program.cs: 2{nl}",
                 writer.ToString());
         }
     }

--- a/src/DeadCsharp/Output.cs
+++ b/src/DeadCsharp/Output.cs
@@ -4,6 +4,8 @@ using InvalidOperationException = System.InvalidOperationException;
 using Regex = System.Text.RegularExpressions.Regex;
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace DeadCsharp
 {
@@ -78,6 +80,34 @@ namespace DeadCsharp
                     Regex regex = Inspection.CodeRegexes[identifier];
                     writer.WriteLine($"  * \"{identifier}\": {regex}");
                 }
+            }
+
+            if (!hasSuspect)
+            {
+                writer.WriteLine($"OK   {path}");
+            }
+
+            return hasSuspect;
+        }
+
+        /// <summary>
+        /// Generates the report in "FAIL [path]: [count]" format.
+        /// </summary>
+        /// <param name="path">Path to the inspected file</param>
+        /// <param name="suspects">Suspect comments</param>
+        /// <param name="writer">Writer that writes the report</param>
+        /// <returns>true if there was at least one suspect comment</returns>
+        public static bool ReportCountByFile(
+            string path, IEnumerable<Inspection.Suspect> suspects, TextWriter writer)
+        {
+            bool hasSuspect = false;
+
+            var matchedPatterns = new SortedSet<string>();
+
+            if (suspects.Any())
+            {
+                hasSuspect = true;
+                writer.WriteLine($"FAIL {path}: {suspects.Select(x => x.Cues?.Count ?? 0)?.Sum() ?? 0}");
             }
 
             if (!hasSuspect)

--- a/src/DeadCsharp/Program.cs
+++ b/src/DeadCsharp/Program.cs
@@ -10,7 +10,7 @@ namespace DeadCsharp
     // ReSharper disable once ClassNeverInstantiated.Global
     public class Program
     {
-        private static int Handle(string[] inputs, string[]? excludes, bool remove)
+        private static int Handle(string[] inputs, string[]? excludes, bool remove, string? output)
         {
             int exitCode = 0;
 
@@ -43,7 +43,18 @@ namespace DeadCsharp
                 {
                     IEnumerable<Inspection.Suspect> suspects = Inspection.Inspect(tree);
 
-                    bool hasSuspect = Output.Report(path, suspects, Console.Out);
+                    bool hasSuspect = false;
+
+                    switch (output)
+                    {
+                        case "count-by-file":
+                            hasSuspect = Output.ReportCountByFile(path, suspects, Console.Out);
+                            break;
+
+                        default:
+                            hasSuspect = Output.Report(path, suspects, Console.Out);
+                            break;
+                    }
 
                     if (hasSuspect)
                     {
@@ -71,12 +82,15 @@ namespace DeadCsharp
 
                 new Option<bool>(
                     new[] {"--remove", "-r"},
-                    "If set, removes the comments suspected to contain dead code"
-                )
+                    "If set, removes the comments suspected to contain dead code"),
+
+                new Option<string>(
+                    new[] {"--output", "-o"},
+                    "Select output format. Possible values: list-comments (default), count-by-file")
             };
 
             rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create(
-                (string[] inputs, string[] excludes, bool remove) => Handle(inputs, excludes, remove));
+                (string[] inputs, string[] excludes, bool remove, string output) => Handle(inputs, excludes, remove, output));
 
             int exitCode = rootCommand.InvokeAsync(args).Result;
             return exitCode;


### PR DESCRIPTION
**Changes**
A new command line option has been added:
`--output count-by-file`

This will change the output for files containing any dead cues to show the total number of problems in that file in the form:
`FAIL [path]: [count]`

**Why**
My intended use for this is to process the output in PowerShell to get the top 10 files with the most probems in order to find the locations where actions would lead to the greatest benefit.
