### PR TITLE
Exclude opinionated commit messages from CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v2.1.2
-
       - name: Install NET 6.x
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
It makes no sense to disallow nice PR descriptions written by external contributors with headings and all.