### PR TITLE
Fix uploading to coveralls

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "coveralls.net": {
-      "version": "3.0.0",
+      "version": "4.0.1",
       "commands": [
         "csmacnz.Coveralls"
       ]


### PR DESCRIPTION
We update coveralls.net to the latest version to fix failing uploads to coveralls.io.