### PR TITLE
Target .NET 8

### DIFF
--- a/src/DeadCsharp.Test/DeadCsharp.Test.csproj
+++ b/src/DeadCsharp.Test/DeadCsharp.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/src/DeadCsharp/DeadCsharp.csproj
+++ b/src/DeadCsharp/DeadCsharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Version>2.1.0</Version>
         <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
An upgrade to support .NET 8 as this is the Long Term Support (LTS) version supported until 10 November, 2026.

On the other hand, the support of .NET 6 has recently ended at 12 November, 2024.
